### PR TITLE
feat!: Change license to ISC

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,24 +1,7 @@
-BSD 2-Clause License
+ISC License
 
-Copyright (c) 2024, cyber-missile
+Copyright 2024 cyber-missile
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,6 @@ No snakes were harmed during development
 
 ## License
 
-Snekoil is licensed under the [BSD-2-Clause license](LICENSE). Feel free to use, modify, and distribute Snekoil in your projects. Happy coding!
+Snekoil is licensed under the [ISC license](LICENSE). Feel free to use, modify, and distribute Snekoil in your projects. Happy coding!
 
 # Snekoil - Too Good To Be True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "snekoil"
 version = "0.3.4"
 description = "Unreasonably fast"
 authors = ["overflowerror <mail@overflowerror.com>"]
-license = "BSD-2-Clause license"
+license = "ISC"
 readme = "README.md"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Reason being that pypi doesn't recognize BSD-2-clause and ISC and BSD-2-clause are basically equivalent anyway.

I'm marking this as a breaking change since license changes are potentially a big deal. Also we are in major version 0 anyway, so even a breaking change should just get the next minor version number - commitizen is weird. ^^

BREAKING CHANGE: License change